### PR TITLE
Add patch for failure of type null and passing tests issue.

### DIFF
--- a/package/package.js
+++ b/package/package.js
@@ -3,7 +3,7 @@ Package.describe({
   summary: 'Run Meteor package or app tests with Mocha',
   git: 'https://github.com/meteortesting/meteor-mocha.git',
   documentation: '../README.md',
-  version: '0.5.0',
+  version: '0.5.1',
   testOnly: true,
 });
 

--- a/package/server.js
+++ b/package/server.js
@@ -65,7 +65,7 @@ function exitIfDone(type, failures) {
 
     // if no env for TEST_WATCH, tests should exit when done
     if (!runnerOptions.testWatch) {
-      if (clientFailures + serverFailures > 0) {
+      if (clientFailures === null || serverFailures === null || clientFailures + serverFailures > 0) {
         process.exit(1); // exit with non-zero status if there were failures
       } else {
         process.exit(0);


### PR DESCRIPTION
We experience occasionally that client tests were failing but the `clientFailures` are of type `null` and tests were passing. This PR offers a guard against the issue, although it does not fix the underlying issue that `clientFailures` should not be `null`.