### PR TITLE
Use browser-policy to allow inline styles from cdn.rawgit.com

### DIFF
--- a/package/package.js
+++ b/package/package.js
@@ -14,6 +14,7 @@ Package.onUse(function onUse(api) {
   ]);
 
   api.use([
+    'browser-policy',
     'meteortesting:browser-tests@0.1.2'
   ], 'server');
 

--- a/package/server.js
+++ b/package/server.js
@@ -1,4 +1,4 @@
-/* global BrowserPolicy: false */
+import { BrowserPolicy } from 'meteor/browser-policy-common';
 import { mochaInstance } from 'meteor/practicalmeteor:mocha-core';
 import { startBrowser } from 'meteor/meteortesting:browser-tests';
 

--- a/package/server.js
+++ b/package/server.js
@@ -1,3 +1,4 @@
+/* global BrowserPolicy: false */
 import { mochaInstance } from 'meteor/practicalmeteor:mocha-core';
 import { startBrowser } from 'meteor/meteortesting:browser-tests';
 
@@ -5,6 +6,11 @@ import setArgs from './runtimeArgs';
 
 const { mochaOptions, runnerOptions } = setArgs();
 const { grep, invert, reporter, serverReporter, xUnitOutput } = mochaOptions || {};
+
+// Allow the remote mocha.css file to be inserted, in case any CSP stuff
+// exists for the domain.
+BrowserPolicy.content.allowStyleOrigin('https://cdn.rawgit.com');
+BrowserPolicy.content.allowInlineStyles();
 
 // Since intermingling client and server log lines would be confusing,
 // the idea here is to buffer all client logs until server tests have


### PR DESCRIPTION
When used in some Meteor apps, this package fail to load the Mocha.css in browser test window, due to CSP (Content Security Policy). This commit fixes this by allowing the CDN domain to be loaded as an inline style.

**Before**

In browser console:

```
Refused to load the stylesheet 'https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css' because it violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline' http://*.stripe.com https://*.stripe.com".
```

<img width="864" alt="skarmavbild 2018-01-15 kl 14 45 07" src="https://user-images.githubusercontent.com/30257156/34945208-c93b798c-fa02-11e7-84d3-a5efb6a44473.png">

**After**

<img width="855" alt="skarmavbild 2018-01-15 kl 14 44 24" src="https://user-images.githubusercontent.com/30257156/34945205-c61fb5a6-fa02-11e7-9532-cd519ce4098b.png">
