### PR TITLE
🐛 Fix forced dependency on browser-policy

### DIFF
--- a/package/package.js
+++ b/package/package.js
@@ -3,7 +3,7 @@ Package.describe({
   summary: 'Run Meteor package or app tests with Mocha',
   git: 'https://github.com/meteortesting/meteor-mocha.git',
   documentation: '../README.md',
-  version: '0.5.1',
+  version: '0.5.2',
   testOnly: true,
 });
 
@@ -13,10 +13,8 @@ Package.onUse(function onUse(api) {
     'ecmascript@0.3.0',
   ]);
 
-  api.use([
-    'browser-policy@1.0.0',
-    'meteortesting:browser-tests@0.2.0'
-  ], 'server');
+  api.use('meteortesting:browser-tests@0.2.0', 'server');
+  api.use('browser-policy@1.0.0','server', { weak: true });
 
   api.mainModule('client.js', 'client');
   api.mainModule('server.js', 'server');

--- a/package/server.js
+++ b/package/server.js
@@ -1,16 +1,18 @@
-import { BrowserPolicy } from 'meteor/browser-policy-common';
 import { mochaInstance } from 'meteor/practicalmeteor:mocha-core';
 import { startBrowser } from 'meteor/meteortesting:browser-tests';
 
 import setArgs from './runtimeArgs';
 
+if (Package['browser-policy-common']) {
+  import { BrowserPolicy } from 'meteor/browser-policy-common';
+  // Allow the remote mocha.css file to be inserted, in case any CSP stuff
+  // exists for the domain.
+  BrowserPolicy.content.allowInlineStyles();
+  BrowserPolicy.content.allowStyleOrigin('https://cdn.rawgit.com');
+}
+
 const { mochaOptions, runnerOptions } = setArgs();
 const { grep, invert, reporter, serverReporter, xUnitOutput } = mochaOptions || {};
-
-// Allow the remote mocha.css file to be inserted, in case any CSP stuff
-// exists for the domain.
-BrowserPolicy.content.allowStyleOrigin('https://cdn.rawgit.com');
-BrowserPolicy.content.allowInlineStyles();
 
 // Since intermingling client and server log lines would be confusing,
 // the idea here is to buffer all client logs until server tests have


### PR DESCRIPTION
The change in v0.5.1 to support browser-policy(#50) had the side effect of
forcing it's use in all apps that use `meteortesting:mocha`.

This PR changes the dependency to a weak one and checks for it's
presence before applying a content policy.