### PR TITLE
Report uncaught exceptions as failing tests

### DIFF
--- a/package/client.js
+++ b/package/client.js
@@ -3,6 +3,11 @@ import { mocha } from 'meteor/practicalmeteor:mocha-core';
 import prepForHTMLReporter from './prepForHTMLReporter';
 import './browser-shim';
 
+let uncaughtExceptions = 0;
+window.addEventListener('error', () => {
+  uncaughtExceptions++;
+});
+
 function saveCoverage(config, done) {
   if (!config) {
     done();
@@ -56,7 +61,7 @@ function runTests() {
     mocha.run((failures) => {
       saveCoverage(coverageOptions, () => {
         window.testsAreRunning = false;
-        window.testFailures = failures;
+        window.testFailures = failures + uncaughtExceptions;
         window.testsDone = true;
       });
     });


### PR DESCRIPTION
Report uncaught exceptions in the browser as failing tests. This should fix #59.

The code provided in #59 produces the following output:

```
--------------------------------
----- RUNNING SERVER TESTS -----
--------------------------------



  CustomerLogicField
    ✓ Failing on client


  2 passing (29ms)


--------------------------------
----- RUNNING CLIENT TESTS -----
--------------------------------
=> Meteor server restarted
Error: Client only bug

  phantomjs://code/phantomjs_script.js:15 in onError
    http://localhost:3100/app/app.js?hash=ab7a0557504b3482357663324dc6ec420de19004: 42041

  phantomjs://code/phantomjs_script.js:17
    http://localhost:3100/packages/modules-runtime.js?hash=5e485d3e2a49d2506f7ca0df72fcd6a3216a83a5: 353

  phantomjs://code/phantomjs_script.js:17
    http://localhost:3100/packages/modules-runtime.js?hash=5e485d3e2a49d2506f7ca0df72fcd6a3216a83a5: 248

  phantomjs://code/phantomjs_script.js:17


  0 passing (1ms)

All tests finished!

--------------------------------
SERVER FAILURES: 0
CLIENT FAILURES: 1
--------------------------------
=> Exited with code: 1
