### PR TITLE
Don't force mocha reporters at any time.

### DIFF
--- a/package/client.js
+++ b/package/client.js
@@ -47,8 +47,10 @@ function runTests() {
     mocha.options.useColors = true;
   }
 
-  // If no browser-driver is set, you most likely want to run the client-tests manually, right?
-  const currentReporter = runnerOptions.browserDriver ? clientReporter || reporter : 'html';
+  let currentReporter = clientReporter || reporter;
+  if (!currentReporter) {
+    currentReporter = runnerOptions.browserDriver ? 'spec' : 'html';
+  }
 
   if (currentReporter === 'html') {
     // If we're not running client tests automatically in a headless browser, then we

--- a/package/client.js
+++ b/package/client.js
@@ -47,26 +47,27 @@ function runTests() {
     mocha.options.useColors = true;
   }
 
-  if (runnerOptions.browserDriver) {
-    mocha.reporter(clientReporter || reporter);
+  // If no browser-driver is set, you most likely want to run the client-tests manually, right?
+  const currentReporter = runnerOptions.browserDriver ? clientReporter || reporter : 'html';
 
-    // These `window` properties are all used by the client testing script in the
-    // browser-tests package to know what is happening.
-    window.testsAreRunning = true;
-    mocha.run((failures) => {
-      saveCoverage(coverageOptions, () => {
-        window.testsAreRunning = false;
-        window.testFailures = failures;
-        window.testsDone = true;
-      });
-    });
-  } else {
+  if (currentReporter === 'html') {
     // If we're not running client tests automatically in a headless browser, then we
     // probably are going to want to see an HTML reporter when we load the page.
     prepForHTMLReporter(mocha);
-    mocha.reporter('html');
-    mocha.run();
   }
+
+  mocha.reporter(currentReporter);
+
+  // These `window` properties are all used by the client testing script in the
+  // browser-tests package to know what is happening.
+  window.testsAreRunning = true;
+  mocha.run((failures) => {
+    saveCoverage(coverageOptions, () => {
+      window.testsAreRunning = false;
+      window.testFailures = failures;
+      window.testsDone = true;
+    });
+  });
 }
 
 export { runTests };

--- a/package/runtimeArgs.js
+++ b/package/runtimeArgs.js
@@ -27,7 +27,7 @@ export default function setArgs() {
     mochaOptions: {
       grep: MOCHA_GREP || false,
       invert: !!MOCHA_INVERT,
-      reporter: MOCHA_REPORTER || 'spec',
+      reporter: MOCHA_REPORTER,
       serverReporter: SERVER_TEST_REPORTER,
       clientReporter: CLIENT_TEST_REPORTER,
       xUnitOutput: XUNIT_FILE,

--- a/package/server.js
+++ b/package/server.js
@@ -102,7 +102,7 @@ function serverTests(cb) {
   // We need to set the reporter when the tests actually run to ensure no conflicts with
   // other test driver packages that may be added to the app but are not actually being
   // used on this run.
-  mochaInstance.reporter(serverReporter || reporter, {
+  mochaInstance.reporter(serverReporter || reporter || 'spec', {
     output: xUnitOutput,
   });
 


### PR DESCRIPTION
Allows you to use the `html` reporter if you've defined `TEST_BROWSER_DRIVER`.

It even doesn't enforce `html` if `TEST_BROWSER_DRIVER` is not defined, but gives you the choice to use other of the many third-party reporters for mocha.

If neither `CLIENT_TEST_REPORTER`, `SERVER_TEST_REPORTER` nor `MOCHA_REPORTER` are defined it sticks to the previous behavior of choosing `spec` on server and client but uses `html` on the client if `TEST_BROWSER_DRIVER` is defined.