### PR TITLE
Only allow inline and style origins if browser-policy-content exists

### DIFF
--- a/package/server.js
+++ b/package/server.js
@@ -5,7 +5,7 @@ import { startBrowser } from 'meteor/meteortesting:browser-tests';
 import setArgs from './runtimeArgs';
 import handleCoverage from './server.handleCoverage';
 
-if (Package['browser-policy-common']) {
+if (Package['browser-policy-common'] && Package['browser-policy-content']) {
   const { BrowserPolicy } = Package['browser-policy-common'];
 
   // Allow the remote mocha.css file to be inserted, in case any CSP stuff


### PR DESCRIPTION
From https://github.com/meteortesting/meteor-mocha/issues/67

We only use the `browser-policy-framing` package, which makes the check for `Package['browser-policy-common']` pass, but since we don't use `browser-policy-content` we get the following error on test runs now:

```
W20180608-17:13:06.473(0)? (STDERR) TypeError: Cannot read property 'allowInlineStyles' of undefined
W20180608-17:13:06.473(0)? (STDERR)     at server.js (packages/meteortesting:mocha/server.js:13:25)
```

It happens because the check [here assumes we're also using browser-policy-content](https://github.com/meteortesting/meteor-mocha/blob/a9eb0657f129b160dd405271ff6231571b3f8e4c/package/server.js#L8) though we're not.

This should avoid the issue by not modifying content policy if you only include 1 of the `browser-policy` packages.